### PR TITLE
Add schema for component description

### DIFF
--- a/schema/Dockerfile
+++ b/schema/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.9-alpine as dependencies
+
+RUN python -m pip install jsonschema json-schema-for-humans
+
+
+FROM dependencies as sources
+WORKDIR /
+COPY ./schema /schema
+
+
+FROM sources as validate
+ENTRYPOINT ["jsonschema", "/schema/component.schema.json", "--base-uri", "file:///schema/component.schema.json", "--instance"]
+
+
+FROM sources as generate-docs
+RUN mkdir -p /html && generate-schema-doc /schema /html
+
+
+FROM generate-docs as serve-html
+WORKDIR /html
+CMD python -m http.server

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,191 @@
+# JSON Schema for Component Descriptions
+
+As components become more numerous and diverse, it is crucial to have a consistent means of describing individual
+components and the interfaces they provide. A machine-readable component description should contain all necessary
+information to procedurally generate documentation, frontend visualisations and backend services for any new component.
+
+To facilitate this, a JSON schema defines the expected structure and contents of a component description.
+
+The component description is intended to be fully comprehensive and cover the needs of both front and backend users.
+For this reason, some low-level concepts from the backend framework are abstracted.
+
+The sections in this document cover these concepts in more detail.
+Components fundamentally use signals to send and receive data in the form of inputs and outputs. Components
+have parameters with specific types and names that define their behaviour. Components also produce predicates,
+which are special "true / false" signals to indicate specific component states that are used to trigger events.
+
+The last section of this document describes some utility scripts which can be used to interact with the JSON schema,
+and finally describes how to format and save the JSON component description file.
+
+## Signals
+
+The signals of a component should be described according to [signal.schema.json](./schema/signal.schema.json).
+
+A "signal" is the generic term for data on a ROS2 topic. We use "input" to refer to subscriptions, and "output" to refer
+to publications. This keeps the language concise and generic for a user who may not be familiar with ROS2 terminology. 
+
+In the backend implementation, components must register their subscriptions and publications under named topics.
+For lifecycle components, this happens in `on_configure`, and otherwise happens on construction.
+
+In some cases, topic names can be "fixed" and immutable properties of the class. This is more often true for outputs
+than inputs, but can occur in both cases.
+
+However, for a component to be able to subscribe to a topic that another component is publishing at run-time,
+the topic name must be configurable from the application either at the point of instantiation or configuration.
+The way this is currently achieved is through string parameters, usually named as some derivative of "topic_name".
+When configured, the component reads the topic name parameter and registers the corresponding subscriber or publisher.
+
+Similarly, a component must also declare the signal type when registering the subscriptions and publications during
+configuration. For dynamically typed signals, parameters are once again employed in the implementation.
+
+In the frontend application graph, component parameters are displayed as editable fields on the component node.
+But, because signals can be represented visually as edges (connections) between input and output nodes,
+they should not also appear as editable "parameter" fields; this would bloat the apparent number of parameters of a
+component with many signals and cause confusion for the user if there are multiple ways to configure signals.
+
+For this reason, the implementation details of topic names as parameters are abstracted, and those parameters are
+treated as "hidden" from the user. In the component description, the associated parameter is 
+parameter values. In many cases, the literal topic name becomes irrelevant and could be automatically generated, as the
+graph will visually show which components are connected and communicating on the corresponding signals. In practice,
+the name of the topic between connected components should use the default topic name of the output as described
+in the following section.
+
+### Configurable signal topic names
+
+The topic name of a signal is sometimes fixed and sometimes configurable. If the name is
+configurable, then it must have an associated hidden parameter that sets the topic name before configuration. 
+
+The following truth table shows the behaviour when connecting the output of one component with an input of another: 
+
+| Output topic is configurable | Input topic is configurable | Result                                              |
+|------------------------------|-----------------------------|-----------------------------------------------------|
+| False                        | False                       | Compatible only if fixed topic names match          |
+| True                         | False                       | Set output topic name from fixed input topic name   |
+| False                        | True                        | Set input topic name from fixed output topic name   |
+| True                         | True                        | Set input topic name from default output topic name |
+
+The backend application interface is responsible for retrieving and setting the corresponding topic name parameter
+from the application graph and component description.
+
+### Configurable signal types
+
+Similar to signal topic names, the signal type may also be configurable through hidden parameters, and has similar
+behavior when resolving a new signal connection.
+
+| Output type is configurable | Input type is configurable | Result                                  |
+|-----------------------------|----------------------------|-----------------------------------------|
+| False                       | False                      | Compatible only if fixed types match    |
+| True                        | False                      | Set output type from fixed input type   |
+| False                       | True                       | Set input type from fixed output type   |
+| True                        | True                       | Set input type from default output type |
+
+This has the extra caveat that the configurable signal type may only support a subset of all available types.
+For example, a configurable component input might support CartesianPose or CartesianState signals, but nothing else.
+In this case, the `supported_types` property in the signal description should be used along with parameter validation
+by the component itself.
+
+### Signal Collection
+
+Just as the topic name or type of a single signal may be configurable at run-time, so too can the number of input
+signals on a component be configurable.
+
+A signal collection is a dynamic grouping of input signals with compatible types. For example, a WeightedSum component
+supports a variable number of inputs that are defined at the application level. It may combine the outputs from
+two components A and B in one application, but combine five different signals in another.
+
+In the backend application, the dynamically configurable component inputs (subscriptions) of one collection
+are generated from a single `string_array` parameter. The array of topic names in the parameter is used to
+register the corresponding subscriptions.
+
+Input collections are treated as a separate property from normal inputs because the structure of the default topic name
+and topic parameter use arrays instead of simple strings. In addition, the frontend will also treat
+simple input signals and input signal collection differently in terms of visualization and interaction.
+
+When a new signal is added to a signal collection in the frontend, the backend appends the new signal topic name
+to the associated hidden array parameter.  
+
+## Parameters
+
+Component classes declare a fixed set of parameters by name and type. The value of parameters are consumed by the
+component when it is instantiated, or, in the case of lifecycle components, when it is configured.
+
+Parameters can have a default value and in some cases are optional.
+
+If a parameter is dynamically reconfigurable, it implies that the parameter can be changed after the component
+is already configured to influence the run-time behaviour.
+This requires the component to either poll the parameter value while running or implement a parameter change callback.
+
+## Predicates
+
+Predicates are crucial to drive the event logic of the dynamic state engine, but they are very simple to declare
+and describe. Each predicate of a component indicates a particular run-time state or configuration that is either
+"true" or "false". In the implementation, a predicate is a publisher with a boolean type. The component is responsible
+for determining the value of a predicate and publishing it under a particular topic name.
+
+In the component description, predicates have a display name and description. The `predicate_name` property is used
+to inform the state engine of the hidden topic name to listen to for that predicate.
+
+## Services
+
+Services are endpoints provided by a component that can trigger certain behaviours. In the backend implementation,
+they are created as ROS2 services with a specific `service_name` using one of two service message types. The first
+type is simply an empty trigger service that has no payload, which is the default case. The second type is a trigger
+service with a string payload, which can be used to pass parameters to the service call. The `has_payload` property
+in the component description is used to specify the service type.
+
+## Inheritance
+
+Components can inherit signals, parameters, predicates and services from another component. This design pattern is
+useful for generating a number of specific component variants that all derive from a common base class.
+
+When component classes define their inheritance in C++ or Python implementations, the respective JSON component
+descriptions can recursively include the full description of their parent components under the top-level `inherits`
+property.
+
+In practice, writing and storing nested JSON descriptions on file is not advisable since this leads to information
+duplication and potential inconsistencies. Instead of a full component description, the `inherits` property can
+alternatively be filled with a registration entry, listing just the `package` and `class` of the parent
+component.
+
+In both cases, the inheritance property should be used by a description parser or consumer to recursively expand all
+properties (signals, parameters, predicates and services) into a flat and fully-comprehensive component description.
+
+## Scripts
+
+Two simple utility scripts are provided to view the schema and to validate JSON component descriptions.
+
+To view the schema specifications in a nicer format, run the [`./serve-html.sh`](./serve-html.sh) script in this
+directory. This will invoke a dockerized process in which a Python module `json-schema-for-humans` generate a static
+HTML representation of the schema which is served on a localhost port for viewing in the browser.
+
+To validate a component description, run the [`./validate.sh`](./validate.sh) script with a path to a JSON file.
+The path can be relative or absolute. For example,
+`./validate.sh examples/foo.json` or `./validate.sh /path/to/foo.json`.
+
+Any invalidities in the component description, such as missing required fields, will be reported.
+
+## Saving the component description
+
+The component description JSON file should be saved in a `component_descriptions` directory of the package as a
+`lower_snake_case` version of the registered class name.
+
+For example, a component class in package `foo_package` registered as `foo_package::Foo` should be saved as follows:
+```
+foo_package/
+    component_descriptions/
+        foo_package_foo.json
+    include/
+        foo_package/
+            Foo.h
+    src/
+        Foo.cpp
+    ...
+```
+
+The component package `CMakeLists.txt` should include the following installation directive, which will install all
+descriptions to `${WORKSPACE}/install/<package_name>/component_descriptions`.
+
+```cmake
+install(DIRECTORY ./component_descriptions
+        DESTINATION .)
+```

--- a/schema/examples/foo.json
+++ b/schema/examples/foo.json
@@ -1,0 +1,110 @@
+{
+  "name": "Foo",
+  "description": {
+    "brief": "An example component",
+    "details": "A longer description of the example component"
+  },
+  "registration": {
+    "package": "foo_package",
+    "class": "foo_package::Foo"
+  },
+  "is_lifecycle": false,
+  "inputs": [
+    {
+      "display_name": "Input 1",
+      "description": "An example input",
+      "signal_type": "bool",
+      "signal_topic": "~/foo_in"
+    }
+  ],
+  "input_collections": [
+    {
+      "display_name": "Input Collection 1",
+      "description": "An example dynamic input collection",
+      "signal_type": "int",
+      "topic_array_parameter": "foo_dynamic_in_1_topic_names"
+    },
+    {
+      "display_name": "Input Collection 2",
+      "description": "Another example dynamic input collection with default initial inputs",
+      "signal_type": "string",
+      "topic_array_parameter": "foo_dynamic_in_2_topic_names",
+      "signal_topic_array": [
+        "~/default_in_x",
+        "~/default_in_y",
+        "~/default_in_z"
+      ]
+    },
+    {
+      "display_name": "Input Collection 3",
+      "description": "Another example dynamic input collection with configurable type",
+      "signal_type": "joint_positions",
+      "topic_array_parameter": "foo_dynamic_in_3_topic_names",
+      "configurable_type": true,
+      "type_parameter": "foo_dynamic_in_3_type",
+      "supported_types": ["joint_positions", "joint_state"]
+    }
+  ],
+  "outputs": [
+    {
+      "display_name": "Output 1",
+      "description": "An example output",
+      "signal_type": "cartesian_pose",
+      "signal_topic": "~/foo_out_1",
+      "configurable_topic": true,
+      "topic_parameter": "foo_out_1_topic_name"
+    },
+    {
+      "display_name": "Output 2",
+      "description": "Another example output",
+      "signal_type": "cartesian_state",
+      "signal_topic": "~/foo_out_2",
+      "configurable_type": true,
+      "type_parameter": "foo_out_2_type",
+      "supported_types": ["cartesian_pose", "cartesian_twist", "cartesian_state"]
+    }
+  ],
+  "parameters": [
+    {
+      "display_name": "Parameter X",
+      "description": "An example parameter",
+      "parameter_name": "parameter_x",
+      "parameter_type": "int"
+    },
+    {
+      "display_name": "Parameter Y",
+      "description": "An example optional parameter",
+      "parameter_name": "parameter_y",
+      "parameter_type": "string",
+      "default_value": "some_default_value",
+      "optional": true
+    },
+    {
+      "display_name": "Parameter Z",
+      "description": "An example parameter that can be dynamically reconfigured while the component is active",
+      "parameter_name": "parameter_z",
+      "parameter_type": "double_array",
+      "dynamic": true
+    }
+  ],
+  "predicates": [
+    {
+      "display_name": "Predicate Alpha",
+      "description": "An example predicate",
+      "predicate_name": "is_alpha"
+    }
+  ],
+  "services": [
+    {
+      "display_name": "Trigger Service",
+      "description": "An example service",
+      "service_name": "trigger_something"
+    },
+    {
+      "display_name": "Payload Service",
+      "description": "An example service with a payload",
+      "service_name": "trigger_something_with_parameters",
+      "has_payload": true
+    }
+  ]
+}

--- a/schema/examples/inheritance.json
+++ b/schema/examples/inheritance.json
@@ -1,0 +1,44 @@
+{
+  "name": "C",
+  "description": {
+    "brief": "An example derived component",
+    "details": "This component derives from component B"
+  },
+  "registration": {
+    "package": "example_package",
+    "class": "example_package::C"
+  },
+  "is_lifecycle": true,
+  "inherits": {
+    "name": "B",
+    "description": {
+      "brief": "An example intermediate component",
+      "details": "This is an intermediate component that derives from component A"
+    },
+    "registration": {
+      "package": "example_package",
+      "class": "example_package::B"
+    },
+    "is_lifecycle": true,
+    "inherits": {
+      "package": "example_package",
+      "class": "example_package::A"
+    },
+    "parameters": [
+      {
+        "display_name": "Base parameter",
+        "description": "An example parameter in component B",
+        "parameter_name": "parameter_b",
+        "parameter_type": "int"
+      }
+    ]
+  },
+  "parameters": [
+    {
+      "display_name": "Derived parameter",
+      "description": "An example parameter in component C",
+      "parameter_name": "parameter_c",
+      "parameter_type": "int"
+    }
+  ]
+}

--- a/schema/schema/component.schema.json
+++ b/schema/schema/component.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/component.schema.json",
+  "title": "Dynamic Component Description",
+  "description": "A full description of a dynamic component in the AICA application framework.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The human-readable name of the component.",
+      "type": "string"
+    },
+    "description": {
+      "description": "The human-readable description of this component and its behaviour.",
+      "type": "object",
+      "properties": {
+        "brief": {
+          "description": "A brief (one-line) description of the component for quick reference and tool-tips.",
+          "type": "string"
+        },
+        "details": {
+          "description": "An optional detailed description of the component.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "brief"
+      ]
+    },
+    "registration": {
+      "$ref": "#/$defs/registration"
+    },
+    "is_lifecycle": {
+      "description": "Specify if the component is a managed node with lifecycle states.",
+      "type": "boolean"
+    },
+    "inherits": {
+      "oneOf": [
+        {
+          "$ref": "#"
+        },
+        {
+          "$ref": "#/$defs/registration"
+        }
+      ]
+    },
+    "inputs": {
+      "description": "The fixed input signals (subscriptions) of the component.",
+      "type": "array",
+      "items": {
+        "$ref": "signal.schema.json"
+      },
+      "uniqueItems": true
+    },
+    "input_collections": {
+      "description": "The dynamically assignable input signals (subscriptions) of the component.",
+      "type": "array",
+      "items": {
+        "$ref": "signal_collection.schema.json"
+      },
+      "uniqueItems": true
+    },
+    "outputs": {
+      "description": "The output signals (publications) of the component.",
+      "type": "array",
+      "items": {
+        "$ref": "signal.schema.json"
+      },
+      "uniqueItems": true
+    },
+    "parameters": {
+      "description": "The parameters declared by the component.",
+      "type": "array",
+      "items": {
+        "$ref": "parameter.schema.json"
+      },
+      "uniqueItems": true
+    },
+    "predicates": {
+      "description": "The predicates provided by the component.",
+      "type": "array",
+      "items": {
+        "$ref": "predicate.schema.json"
+      },
+      "uniqueItems": true
+    },
+    "services": {
+      "description": "The services provided by the component.",
+      "type": "array",
+      "items": {
+        "$ref": "service.schema.json"
+      },
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "name",
+    "description",
+    "registration",
+    "is_lifecycle"
+  ],
+  "$defs": {
+    "registration": {
+      "description": "The registration details of the exported component required for run-time loading.",
+      "type": "object",
+      "properties": {
+        "package": {
+          "description": "The name of the package in which this component is defined.",
+          "type": "string"
+        },
+        "class": {
+          "description": "The fully qualified class name used to register the component.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "package",
+        "class"
+      ]
+    }
+  }
+}

--- a/schema/schema/encoded_state_type.schema.json
+++ b/schema/schema/encoded_state_type.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/encoded_state_type.schema.json",
+  "title": "Encoded State Type",
+  "description": "The state type of a encoded value from a collection of supported types, as defined in clproto.",
+  "type": "string",
+  "enum": [
+    "state",
+    "spatial_state",
+    "cartesian_state",
+    "cartesian_pose",
+    "cartesian_twist",
+    "cartesian_acceleration",
+    "cartesian_wrench",
+    "jacobian",
+    "joint_state",
+    "joint_positions",
+    "joint_velocities",
+    "joint_torques",
+    "shape",
+    "ellipsoid",
+    "parameter"
+  ]
+}

--- a/schema/schema/parameter.schema.json
+++ b/schema/schema/parameter.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/parameter.schema.json",
+  "title": "Component Parameter",
+  "description": "A dynamic component parameter that is publicly configurable.",
+  "type": "object",
+  "properties": {
+    "display_name": {
+      "description": "The human-readable parameter name.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A brief description of the parameter.",
+      "type": "string"
+    },
+    "parameter_name": {
+      "description": "The lower_snake_case parameter name as it is declared in the component.",
+      "type": "string"
+    },
+    "parameter_type": {
+      "description": "The parameter value type.",
+      "$ref": "parameter_type.schema.json"
+    },
+    "encoded_state_type": {
+      "description": "The state type of the parameter, if the value type is an encoded state.",
+      "$ref": "encoded_state_type.schema.json"
+    },
+    "default_value": {
+      "description": "The string representation of the default parameter value.",
+      "type": "string"
+    },
+    "optional": {
+      "description": "Specify if this parameter is optional.",
+      "type": "boolean"
+    },
+    "dynamic": {
+      "description": "Specify if this parameter can be dynamically reconfigured while the component is active",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "display_name",
+    "description",
+    "parameter_name",
+    "parameter_type"
+  ],
+  "if": {
+    "properties": {
+      "parameter_type": {
+        "const": "json_encoded_state"
+      }
+    }
+  },
+  "then": {
+    "required": [
+      "encoded_state_type"
+    ]
+  },
+  "dependentSchemas": {
+    "optional": {
+      "if": {
+        "properties": {
+          "optional": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "default_value"
+        ]
+      }
+    }
+  }
+}

--- a/schema/schema/parameter_type.schema.json
+++ b/schema/schema/parameter_type.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/parameter_type.schema.json",
+  "title": "Parameter Type",
+  "description": "The value type of a parameter from a collection of supported types.",
+  "type": "string",
+  "enum": [
+    "bool",
+    "bool_array",
+    "int",
+    "int_array",
+    "double",
+    "double_array",
+    "string",
+    "string_array",
+    "vector",
+    "matrix",
+    "json_encoded_state"
+  ]
+}

--- a/schema/schema/predicate.schema.json
+++ b/schema/schema/predicate.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/predicate.schema.json",
+  "title": "Component Predicate",
+  "description": "A predicate signal parameter of a dynamic component.",
+  "type": "object",
+  "properties": {
+    "display_name": {
+      "description": "The human-readable predicate name.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A brief description of the predicate.",
+      "type": "string"
+    },
+    "predicate_name": {
+      "description": "The lower_snake_case predicate name as it is declared in the component.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "display_name",
+    "description",
+    "predicate_name"
+  ]
+}

--- a/schema/schema/service.schema.json
+++ b/schema/schema/service.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/service.schema.json",
+  "title": "Component Service",
+  "description": "A service endpoint of a dynamic component.",
+  "type": "object",
+  "properties": {
+    "display_name": {
+      "description": "The human-readable service name.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A brief description of the service.",
+      "type": "string"
+    },
+    "service_name": {
+      "description": "The lower_snake_case service name as it is declared in the component.",
+      "type": "string"
+    },
+    "has_payload": {
+      "description": "Indicate if the service has a string payload or is an empty trigger.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "display_name",
+    "description",
+    "service_name"
+  ]
+}

--- a/schema/schema/signal.schema.json
+++ b/schema/schema/signal.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/signal.schema.json",
+  "title": "Component Signal",
+  "description": "A signal associated with a dynamic component that can be an input or an output.",
+  "type": "object",
+  "properties": {
+    "display_name": {
+      "description": "The short name of this signal (to be displayed on the edge of the component).",
+      "type": "string"
+    },
+    "description": {
+      "description": "A description of the signal for tool-tips and documentation.",
+      "type": "string"
+    },
+    "signal_type": {
+      "description": "The default type of this signal (connected inputs and outputs must have compatible types).",
+      "$ref": "signal_type.schema.json"
+    },
+    "signal_topic": {
+      "description": "The default topic name assigned to this signal.",
+      "type": "string"
+    },
+    "configurable_topic": {
+      "description": "Indicate if the signal topic is configurable and can be renamed.",
+      "type": "boolean"
+    },
+    "topic_parameter": {
+      "description": "The name of the hidden component parameter that is used to set the signal topic name.",
+      "type": "string"
+    },
+    "configurable_type": {
+      "description": "Indicate if the signal type is configurable and can be changed.",
+      "type": "boolean"
+    },
+    "supported_types": {
+      "description": "An array of signal types supported by configurable typing.",
+      "type": "array",
+      "items": {
+        "$ref": "signal_type.schema.json"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "type_parameter": {
+      "description": "The name of the hidden component parameter that is used to set the signal topic type.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "display_name",
+    "description",
+    "signal_type",
+    "signal_topic"
+  ],
+  "dependentSchemas": {
+    "configurable_topic": {
+      "if": {
+        "properties": {
+          "configurable_topic": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "topic_parameter"
+        ]
+      }
+    },
+    "configurable_type": {
+      "if": {
+        "properties": {
+          "configurable_type": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "supported_types",
+          "type_parameter"
+        ]
+      }
+    }
+  }
+}

--- a/schema/schema/signal_collection.schema.json
+++ b/schema/schema/signal_collection.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/input_signal_collection.schema.json",
+  "title": "Input Signal Collection",
+  "description": "A dynamic collection of input signals that can have zero or more topics of the same type.",
+  "type": "object",
+  "properties": {
+    "display_name": {
+      "description": "The short name of this input signal collection (to be displayed on the edge of the component).",
+      "type": "string"
+    },
+    "description": {
+      "description": "A description of the signal collection for tool-tips and documentation.",
+      "type": "string"
+    },
+    "signal_type": {
+      "description": "The default type of the signals (signals in a collection must have the same type).",
+      "$ref": "signal_type.schema.json"
+    },
+    "signal_topic_array": {
+      "description": "The optional default array of topic names in this signal collection.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "topic_array_parameter": {
+      "description": "The name of the hidden component parameter that is used to set the array of signal topic names.",
+      "type": "string"
+    },
+    "configurable_type": {
+      "description": "Indicate if the signal collection type is configurable and can be changed.",
+      "type": "boolean"
+    },
+    "supported_types": {
+      "description": "An array of signal types supported by configurable typing.",
+      "type": "array",
+      "items": {
+        "$ref": "signal_type.schema.json"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "type_parameter": {
+      "description": "The name of the hidden component parameter that is used to set the signal collection type.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "display_name",
+    "description",
+    "signal_type",
+    "topic_array_parameter"
+  ],
+  "dependentSchemas": {
+    "configurable_type": {
+      "if": {
+        "properties": {
+          "configurable_type": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "supported_types",
+          "type_parameter"
+        ]
+      }
+    }
+  }
+}

--- a/schema/schema/signal_type.schema.json
+++ b/schema/schema/signal_type.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "id": "https://github.com/aica-technology/dynamic-components/schema/schema/signal_type.schema.json",
+  "title": "Signal Type",
+  "description": "Supported signal value types as simple atomic types or encoded state types.",
+  "anyOf": [
+    {
+      "type": "string",
+      "enum": [
+        "bool",
+        "int",
+        "double",
+        "string"
+      ]
+    },
+    {
+      "$ref": "encoded_state_type.schema.json"
+    }
+  ]
+}

--- a/schema/serve-html.sh
+++ b/schema/serve-html.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ "$#" -ne 0 ]; then
+    echo "Usage: ./serve-html.sh"
+    exit 0
+fi
+
+IMAGE_NAME=aica-technology/dynamic-components/schema:html
+CONTAINER_NAME=aica-technology-dynamic-components-schema-html
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+docker build --target serve-html --tag "${IMAGE_NAME}" "${SCRIPT_DIR}"
+
+echo "Starting an html server container on localhost:8000"
+docker run -d --rm -p 8000:8000 --name "${CONTAINER_NAME}" "${IMAGE_NAME}"
+
+WEB_PATH=http://localhost:8000/component.schema.html
+if [ "$(command -v python)" ]; then
+  python -m webbrowser "${WEB_PATH}"
+elif [ "$(command -v python3)" ]; then
+  python3 -m webbrowser "${WEB_PATH}"
+elif [ "$(command -v php)" ]; then
+  echo "HTML server running! Visit the following address in a browser:"
+  echo ">> ${WEB_PATH}"
+fi
+
+read -n 1 -s -r -p "Press any key to stop the html server container"
+echo ""
+echo "Stopping the container"
+docker container rm --force "${CONTAINER_NAME}"

--- a/schema/validate.sh
+++ b/schema/validate.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ./validate.sh /path/to/component_description.json"
+    exit 0
+fi
+
+JSON_FILE="$1"
+FULL_PATH="$(cd "$(dirname "$1")" || exit 1; pwd)"
+FILENAME=$(basename "${JSON_FILE}")
+
+IMAGE_NAME=aica-technology/dynamic-components/schema:validate
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+docker build --target validate --tag "${IMAGE_NAME}" "${SCRIPT_DIR}"
+
+# mount a volume to share the file, attach to stderr, pass the filename to the entrypoint and redirect any output from stderr to stdout
+STDERR_CAPTURE=$(docker run -a stderr --rm --volume "$FULL_PATH":/home/validate "${IMAGE_NAME}" \
+  "/home/validate/${FILENAME}" 2>&1 >/dev/null)
+if [ -n "$STDERR_CAPTURE" ]; then
+  echo "Failure: ${FILENAME} is not a valid component description!"
+  echo "${STDERR_CAPTURE}"
+else
+  echo "Success: ${FILENAME} is a valid component description."
+fi


### PR DESCRIPTION
* Migrate JSON schema for component description from dynamic-components repository

The directory was migrated as-is from dynamic components in [this twinned PR](https://github.com/aica-technology/dynamic-components/pull/106).

@buschbapti @domire8 