### PR TITLE
Create installation directory for each installation

### DIFF
--- a/scripts/install_component_package.sh
+++ b/scripts/install_component_package.sh
@@ -28,6 +28,7 @@ function install_dependencies() {
     for SCRIPT in "${INSTALL_SCRIPT[@]}"
     do
         if [ -n "${SCRIPT}" ]; then
+            mkdir -p "${INSTALLATION_DIR}" || exit 1
             cd "${INSTALLATION_DIR}" || exit 1
             echo "Running install script: ${SCRIPT}"
             bash "${SCRIPT}" || exit 1
@@ -101,7 +102,6 @@ else
   echo "${HELP_MESSAGE}" && exit 1
 fi
 
-mkdir -p "${INSTALLATION_DIR}" || exit 1
 for COMPONENT in "${COMPONENT_LIST[@]}"; do
   if [ -n "${COMPONENT}" ]; then
     cd "${CURRENT_DIR}" || exit 1


### PR DESCRIPTION
Sneaky one here. Previously, the installation directory was created before the components were installed and removed after. However, if a component installs another component (the install script is called from the install script), the install directory will be removed at the end of that and then the next component in line will complain because the directory doesn't anymore...