### PR TITLE
Release Version 0.4.0

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -266,9 +266,10 @@ To set up validation for the component description schema, follow the steps give
 [Configure a custom JSON schema](https://www.jetbrains.com/help/clion/json.html#6768673a).
 
 For step 3, give the Schema a useful name (such as "Component Description") and choose JSON Schema version 7.
-In the "Schema file or URL field", specify the path to the `component.schema.json` file.
-For example, if the local copy of the Component SDK repository is saved to `/home/user/component-sdk`,
-then specify the Schema file path as `/home/user/component-sdk/schema/schema/component.schema.json`.
+In the "Schema file or URL field", enter the following URL:
+```
+https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/component.schema.json
+```
 
 For step 4, either manually specify files and directories to be validated, or use the file path pattern
 `component_descriptions/*.json` to detect all component description in compatible packages.

--- a/schema/examples/foo.json
+++ b/schema/examples/foo.json
@@ -5,7 +5,7 @@
     "details": "A longer description of the example component"
   },
   "registration": "foo_package::Foo",
-  "inherits": "modulo_componentss::Component",
+  "inherits": "modulo_components::Component",
   "inputs": [
     {
       "display_name": "Input 1",

--- a/schema/schema/component.schema.json
+++ b/schema/schema/component.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/component.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/component.schema.json",
   "title": "Dynamic Component Description",
   "description": "A full description of a dynamic component in the AICA application framework.",
   "type": "object",

--- a/schema/schema/encoded_state_type.schema.json
+++ b/schema/schema/encoded_state_type.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/encoded_state_type.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/encoded_state_type.schema.json",
   "title": "Encoded State Type",
   "description": "The state type of an encoded value from a collection of supported types, as defined in clproto.",
   "type": "string",

--- a/schema/schema/parameter.schema.json
+++ b/schema/schema/parameter.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/parameter.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/parameter.schema.json",
   "title": "Component Parameter",
   "description": "A dynamic component parameter that is publicly configurable.",
   "type": "object",

--- a/schema/schema/parameter_type.schema.json
+++ b/schema/schema/parameter_type.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/parameter_type.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/parameter_type.schema.json",
   "title": "Parameter Type",
   "description": "The value type of a parameter from a collection of supported types.",
   "type": "string",

--- a/schema/schema/predicate.schema.json
+++ b/schema/schema/predicate.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/predicate.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/predicate.schema.json",
   "title": "Component Predicate",
   "description": "A predicate signal parameter of a dynamic component.",
   "type": "object",

--- a/schema/schema/service.schema.json
+++ b/schema/schema/service.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/service.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/service.schema.json",
   "title": "Component Service",
   "description": "A service endpoint of a dynamic component.",
   "type": "object",

--- a/schema/schema/signal.schema.json
+++ b/schema/schema/signal.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/signal.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/signal.schema.json",
   "title": "Component Signal",
   "description": "A signal associated with a dynamic component that can be an input or an output.",
   "type": "object",

--- a/schema/schema/signal_collection.schema.json
+++ b/schema/schema/signal_collection.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/input_signal_collection.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/input_signal_collection.schema.json",
   "title": "Input Signal Collection",
   "description": "A dynamic collection of input signals that can have zero or more topics of the same type.",
   "type": "object",

--- a/schema/schema/signal_type.schema.json
+++ b/schema/schema/signal_type.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "id": "https://github.com/aica-technology/component-sdk/schema/schema/signal_type.schema.json",
+  "id": "https://raw.githubusercontent.com/aica-technology/component-sdk/main/schema/schema/signal_type.schema.json",
   "title": "Signal Type",
   "description": "Supported signal value types as simple atomic types or encoded state types.",
   "anyOf": [

--- a/scripts/create_component_package.sh
+++ b/scripts/create_component_package.sh
@@ -73,6 +73,13 @@ cp -r "${TEMPLATE_DIR}" "${COMPONENT_PKG_DIR}"
 mv "${COMPONENT_PKG_DIR}"/template_component_package "${COMPONENT_PKG_DIR}"/"${COMPONENT_PKG_NAME}"
 mv "${COMPONENT_PKG_DIR}"/include/template_component_package "${COMPONENT_PKG_DIR}"/include/"${COMPONENT_PKG_NAME}"
 
+# rename the template component descriptions
+DESCRIPTION_DIR="${COMPONENT_PKG_DIR}"/component_descriptions
+mv "${DESCRIPTION_DIR}"/template_component_package_cpp_component.json "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_cpp_component.json
+mv "${DESCRIPTION_DIR}"/template_component_package_cpp_lifecycle_component.json "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_cpp_lifecycle_component.json
+mv "${DESCRIPTION_DIR}"/template_component_package_py_component.json "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_py_component.json
+mv "${DESCRIPTION_DIR}"/template_component_package_py_lifecycle_component.json "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_py_lifecycle_component.json
+
 # sed template_component_package in files
 if [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/README.md
@@ -93,6 +100,11 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
   sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/"${COMPONENT_PKG_NAME}"/py_lifecycle_component.py
   sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/test/python_tests/test_py_lifecycle_component.py
+
+  sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_cpp_component.json
+  sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_cpp_lifecycle_component.json
+  sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_py_component.json
+  sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_py_lifecycle_component.json
 
   sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/Dockerfile
   sed -i '' "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/build-server.sh
@@ -115,6 +127,11 @@ else
 
   sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/"${COMPONENT_PKG_NAME}"/py_lifecycle_component.py
   sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/test/python_tests/test_py_lifecycle_component.py
+
+  sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_cpp_component.json
+  sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_cpp_lifecycle_component.json
+  sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_py_component.json
+  sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${DESCRIPTION_DIR}"/"${COMPONENT_PKG_NAME}"_py_lifecycle_component.json
 
   sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/Dockerfile
   sed -i "s/template_component_package/${COMPONENT_PKG_NAME}/g" "${COMPONENT_PKG_DIR}"/build-server.sh

--- a/source/template_component_package/CMakeLists.txt
+++ b/source/template_component_package/CMakeLists.txt
@@ -43,6 +43,9 @@ install(TARGETS ${COMPONENTS}
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin)
 
+install(DIRECTORY ./component_descriptions
+        DESTINATION .)
+
 # install Python modules
 ament_python_install_package(${PROJECT_NAME} SCRIPTS_DESTINATION lib/${PROJECT_NAME})
 

--- a/source/template_component_package/component_descriptions/README.md
+++ b/source/template_component_package/component_descriptions/README.md
@@ -1,0 +1,6 @@
+# Component Descriptions
+
+Each registered component should have a corresponding json description file in this directory,
+formatted according to the component description schema.
+
+More info: https://github.com/aica-technology/component-sdk/tree/main/schema

--- a/source/template_component_package/component_descriptions/template_component_package_cpp_component.json
+++ b/source/template_component_package/component_descriptions/template_component_package_cpp_component.json
@@ -1,0 +1,9 @@
+{
+  "name": "Template CPP Component",
+  "description": {
+    "brief": "Brief description of the component",
+    "details": "Detailed description of the component."
+  },
+  "registration": "template_component_package::CPPComponent",
+  "inherits": "modulo_components::Component"
+}

--- a/source/template_component_package/component_descriptions/template_component_package_cpp_lifecycle_component.json
+++ b/source/template_component_package/component_descriptions/template_component_package_cpp_lifecycle_component.json
@@ -1,0 +1,9 @@
+{
+  "name": "Template CPP Lifecycle Component",
+  "description": {
+    "brief": "Brief description of the component",
+    "details": "Detailed description of the component."
+  },
+  "registration": "template_component_package::CPPLifecycleComponent",
+  "inherits": "modulo_components::LifecycleComponent"
+}

--- a/source/template_component_package/component_descriptions/template_component_package_py_component.json
+++ b/source/template_component_package/component_descriptions/template_component_package_py_component.json
@@ -1,0 +1,9 @@
+{
+  "name": "Template Python Component",
+  "description": {
+    "brief": "Brief description of the component",
+    "details": "Detailed description of the component."
+  },
+  "registration": "template_component_package::PyComponent",
+  "inherits": "modulo_components::Component"
+}

--- a/source/template_component_package/component_descriptions/template_component_package_py_lifecycle_component.json
+++ b/source/template_component_package/component_descriptions/template_component_package_py_lifecycle_component.json
@@ -1,0 +1,9 @@
+{
+  "name": "Template Python Lifecycle Component",
+  "description": {
+    "brief": "Brief description of the component",
+    "details": "Detailed description of the component."
+  },
+  "registration": "template_component_package::PyLifecycleComponent",
+  "inherits": "modulo_components::LifecycleComponent"
+}


### PR DESCRIPTION
This is a small release containing only #24. The main difference is that the base URI of the component description schemas now point to raw files on the GitHub main branch. By releasing this onto main and making it public, it will then be possible to refer to the schema at the public URI, which will make it easier to validate descriptions both in our IDEs and in the frontend.

After this is merged, I will make the repository public! If you have any concerns with that, then this PR is the place to discuss it.

🚂 @buschbapti @domire8