### PR TITLE
Allow custom signal types

### DIFF
--- a/schema/examples/foo.json
+++ b/schema/examples/foo.json
@@ -23,6 +23,13 @@
         "double_array"
       ],
       "default_type": "double"
+    },
+    {
+      "description": "Input 3",
+      "display_name": "An example input with a custom signal type",
+      "signal_name": "foo_in_3",
+      "signal_type": "other",
+      "custom_signal_type": "foo"
     }
   ],
   "input_collections": [

--- a/schema/schema/parameter.schema.json
+++ b/schema/schema/parameter.schema.json
@@ -41,8 +41,12 @@
         null
       ],
       "anyOf": [
-        {"type": "string"},
-        {"type": "null"}
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "dynamic": {
@@ -57,20 +61,16 @@
     "parameter_type",
     "default_value"
   ],
-  "anyOf": [
-    {
-      "not": {
-        "properties": {
-          "parameter_type": {
-            "const": "state"
-          }
-        }
+  "if": {
+    "properties": {
+      "parameter_type": {
+        "const": "state"
       }
-    },
-    {
-      "required": [
-        "parameter_state_type"
-      ]
     }
-  ]
+  },
+  "then": {
+    "required": [
+      "parameter_state_type"
+    ]
+  }
 }

--- a/schema/schema/signal.schema.json
+++ b/schema/schema/signal.schema.json
@@ -77,5 +77,34 @@
         "default_type"
       ]
     }
-  ]
+  ],
+  "if": {
+    "not": {
+      "required": [
+        "signal_type"
+      ]
+    }
+  },
+  "else": {
+    "if": {
+      "properties": {
+        "signal_type": {
+          "const": "other"
+        }
+      }
+    },
+    "then": {
+      "custom_signal_type": {
+        "description": "The custom signal type of the signal",
+        "examples": [
+          "sensor_msgs::msg::JointState",
+          "geometry_msgs::msg::Pose"
+        ],
+        "type": "string"
+      },
+      "required": [
+        "custom_signal_type"
+      ]
+    }
+  }
 }

--- a/schema/schema/signal_type.schema.json
+++ b/schema/schema/signal_type.schema.json
@@ -11,7 +11,8 @@
         "int",
         "double",
         "double_array",
-        "string"
+        "string",
+        "other"
       ]
     },
     {


### PR DESCRIPTION
Here, I'm adding the custom signal type to the signal schema. I used `if then else` blocks for that:
- Because `signal_type` is not a required property by default, we cannot just say `if signal_type==other; then require custom_signal_type`
- Instead, we can do
  ```
  if signal_type is not provided:
    pass
  else:
    if signal_type == other:
      require field custom_signal_type
  ```

I think `if then else` blocks will become more and more important as we refine the schema because it will allow for more complex blocks than `oneOf allOf` etc and we could also forbid some fields if others are provided (e.g. signal_type and signal_types should be mutually exclusive technically)