### PR TITLE
Test if package.xml exists in potential package directory

### DIFF
--- a/scripts/install_component_package.sh
+++ b/scripts/install_component_package.sh
@@ -4,7 +4,7 @@
 # there might be subdirectories containing the same name so we only select first occurrence
 # tilde extension is used to return absolute path for subsequent finds
 function install_dependencies() {
-    COMPONENT_DIR="$(find ~+ -type d -name "$1" -print -quit)"
+    COMPONENT_DIR="$(find ~+ -type d -name "$1" -exec test -e '{}'/package.xml \; -print -quit)"
     DESTINATION_DIR="$2"
     INSTALLATION_DIR="$3"
 


### PR DESCRIPTION
This addresses the issue that was mentioned in [this PR](https://github.com/aica-technology/dynamic-components/pull/199#pullrequestreview-1201059669). Instead of just blindly accepting the first directory that has the same name as the desired package, we check if there is actually a `package.xml` file in there.

@buschbapti 