### PR TITLE
Install component dependencies in subdirectory

### DIFF
--- a/scripts/install_component_package.sh
+++ b/scripts/install_component_package.sh
@@ -6,7 +6,7 @@
 function install_dependencies() {
     COMPONENT_DIR="$(find ~+ -type d -name "$1" -exec test -e '{}'/package.xml \; -print -quit)"
     DESTINATION_DIR="$2"
-    INSTALLATION_DIR="$3"
+    INSTALLATION_DIR="$3"/"$1"
 
     if [ -z "${COMPONENT_DIR}" ]; then
         echo "Component not found"
@@ -40,6 +40,7 @@ function install_dependencies() {
       echo "Moving component from ${COMPONENT_DIR} to ${DESTINATION_DIR}"
       cp -rn "${COMPONENT_DIR}" "${DESTINATION_DIR}"
     fi
+    rm -rf "${INSTALLATION_DIR}"
     echo "Installation of component $1 complete"
 }
 
@@ -115,4 +116,4 @@ for COMPONENT in "${COMPONENT_LIST[@]}"; do
     fi
   fi
 done
-cd "${CURRENT_DIR}" && rm -rf "${INSTALLATION_DIR}" || exit 1
+cd "${CURRENT_DIR}" || exit 1


### PR DESCRIPTION
There was still a problem with the recursive installation of components. The removal of the installation directory can cause problems. I'm therefore proposing to create a directory with the name of the component, do the installation in there, and then delete that subdirectory instead of the whole installation directory

@buschbapti 